### PR TITLE
Massive performance improvement

### DIFF
--- a/Sources/SwiftCBOR/CBORDecoder.swift
+++ b/Sources/SwiftCBOR/CBORDecoder.swift
@@ -27,7 +27,7 @@ public class CBORDecoder {
     }
 
     public init(input: [UInt8]) {
-        istream = ArrayUInt8(array: input)
+        istream = ArrayUInt8(array: ArraySlice(input))
     }
 
     func readBinaryNumber<T>(_ type: T.Type) throws -> T {

--- a/Sources/SwiftCBOR/CBORInputStream.swift
+++ b/Sources/SwiftCBOR/CBORInputStream.swift
@@ -9,7 +9,7 @@ struct ArraySliceUInt8 {
 }
 
 struct ArrayUInt8 {
-    var array : Array<UInt8>
+    var array : ArraySlice<UInt8>
 }
 
 extension ArraySliceUInt8: CBORInputStream {
@@ -35,7 +35,7 @@ extension ArrayUInt8: CBORInputStream {
     mutating func popBytes(_ n: Int) throws -> ArraySlice<UInt8> {
         guard array.count >= n else { throw CBORError.unfinishedSequence }
         let res = array.prefix(n)
-        array = Array(array.dropFirst(n))
+        array = array.dropFirst(n)
         return res
     }
 }


### PR DESCRIPTION
The current implementation constantly recreates Arrays while popping bytes from the CBORInputStream, which is especially painful on older iOS devices but also noticeable on certain CBOR payloads on fast devices. This can be easily and massively improved by always using ArraySlice instead of Array because this avoids the recreation and copying of data.

In our tests with EU DGC business rules on an iPad Mini 2 (Model Number A1490) running iOS 12.5.4 with a small CBOR file (~210KB) the old implementation took 500 seconds (= more than 8 minutes !!) to decode the payload. With this small improvement the decoding time for the same payload on that same device reduced to just 18 seconds (or 3,6% of the original decoding time)