### PR TITLE
Massive performance improvements by switching from using Data to ArraySlice

### DIFF
--- a/Sources/SwiftCBOR/Decoder/KeyedDecodingContainer.swift
+++ b/Sources/SwiftCBOR/Decoder/KeyedDecodingContainer.swift
@@ -66,12 +66,12 @@ extension _CBORDecoder {
             }
         }()
 
-        var data: Data
+        var data: ArraySlice<UInt8>
         var index: Data.Index
         var codingPath: [CodingKey]
         var userInfo: [CodingUserInfoKey: Any]
 
-        init(data: Data, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
+        init(data: ArraySlice<UInt8>, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
             self.codingPath = codingPath
             self.userInfo = userInfo
             self.data = data

--- a/Sources/SwiftCBOR/Decoder/SingleValueDecodingContainer.swift
+++ b/Sources/SwiftCBOR/Decoder/SingleValueDecodingContainer.swift
@@ -4,10 +4,10 @@ extension _CBORDecoder {
     final class SingleValueContainer {
         var codingPath: [CodingKey]
         var userInfo: [CodingUserInfoKey: Any]
-        var data: Data
+        var data: ArraySlice<UInt8>
         var index: Data.Index
 
-        init(data: Data, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
+        init(data: ArraySlice<UInt8>, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
             self.codingPath = codingPath
             self.userInfo = userInfo
             self.data = data

--- a/Sources/SwiftCBOR/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/SwiftCBOR/Decoder/UnkeyedDecodingContainer.swift
@@ -10,7 +10,7 @@ extension _CBORDecoder {
 
         var userInfo: [CodingUserInfoKey: Any]
 
-        var data: Data
+        var data: ArraySlice<UInt8>
         var index: Data.Index
 
         lazy var count: Int? = {
@@ -70,8 +70,8 @@ extension _CBORDecoder {
 
             return nestedContainers
         }
-
-        init(data: Data, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
+        
+        init(data: ArraySlice<UInt8>, codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
             self.codingPath = codingPath
             self.userInfo = userInfo
             self.data = data
@@ -96,6 +96,7 @@ extension _CBORDecoder {
 }
 
 extension _CBORDecoder.UnkeyedContainer: UnkeyedDecodingContainer {
+   
     func decodeNil() throws -> Bool {
         try checkCanDecodeValue()
         defer { self.currentIndex += 1 }
@@ -190,16 +191,16 @@ extension _CBORDecoder.UnkeyedContainer {
         case 0x60...0x77:
             length = try CBORDecoder(input: [0]).readLength(format, base: 0x60)
         case 0x78:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1)).map { $0 }
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
             length = try CBORDecoder(input: remainingData).readLength(format, base: 0x60) + 1
         case 0x79:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1)).map { $0 }
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
             length = try CBORDecoder(input: remainingData).readLength(format, base: 0x60) + 2
         case 0x7a:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1)).map { $0 }
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
             length = try CBORDecoder(input: remainingData).readLength(format, base: 0x60) + 4
         case 0x7b:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1)).map { $0 }
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
             length = try CBORDecoder(input: remainingData).readLength(format, base: 0x60) + 8
         // Terminated by break
         case 0x7f:
@@ -244,7 +245,7 @@ extension _CBORDecoder.UnkeyedContainer {
         let range: Range<Data.Index> = startIndex..<self.index.advanced(by: length)
         self.index = range.upperBound
 
-        let container = _CBORDecoder.SingleValueContainer(data: self.data.subdata(in: range), codingPath: self.codingPath, userInfo: self.userInfo)
+        let container = _CBORDecoder.SingleValueContainer(data: self.data[range.startIndex..<(range.endIndex)], codingPath: self.codingPath, userInfo: self.userInfo)
 
         return container
     }

--- a/Sources/SwiftCBOR/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/SwiftCBOR/Decoder/UnkeyedDecodingContainer.swift
@@ -35,7 +35,7 @@ extension _CBORDecoder {
                     // decoding each item in the array.
                     let nextIndex = self.data.startIndex.advanced(by: 1)
                     let remainingData = self.data.suffix(from: nextIndex)
-                    return try? CBORDecoder(input: remainingData.map { $0 }).readUntilBreak().count
+                    return try? CBORDecoder(input: remainingData).readUntilBreak().count
                 default:
                     return nil
                 }
@@ -172,16 +172,16 @@ extension _CBORDecoder.UnkeyedContainer {
         case 0x40...0x57:
             length = try CBORDecoder(input: [0]).readLength(format, base: 0x40)
         case 0x58:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1)).map { $0 }
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
             length = try CBORDecoder(input: remainingData).readLength(format, base: 0x40) + 1
         case 0x59:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1)).map { $0 }
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
             length = try CBORDecoder(input: remainingData).readLength(format, base: 0x40) + 2
         case 0x5a:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1)).map { $0 }
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
             length = try CBORDecoder(input: remainingData).readLength(format, base: 0x40) + 4
         case 0x5b:
-            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1)).map { $0 }
+            let remainingData = self.data.suffix(from: startIndex.advanced(by: 1))
             length = try CBORDecoder(input: remainingData).readLength(format, base: 0x40) + 8
         // Terminated by break
         case 0x5f:


### PR DESCRIPTION
Another massive performance improvement for decoding. The decoder and decoding containers previously used to constantly create new Data objects while parsing the payload (suffix in combination with map) leading to hundreds of thousands recreated data structures even while parsing a small payload. This change massively improves the performance by completely switching to ArraySlice for the individual bytes instead of recreating objects.

The attached images show the before and after for test cases we have written which parse the data from the Acceptance System of the Austrian Gateway for EU Digital COVID Certificates (See https://github.com/Federal-Ministry-of-Health-AT/green-pass-overview for the endpoints about trustlist, business rules and value sets) which improves the parsing speed by a factor of 60 (from 80 seconds to 2 seconds) when testing in the simulator, while real world improvements are even more dramatic and become greater with device age.

<img width="439" alt="before" src="https://user-images.githubusercontent.com/73990/134050921-198e244e-3cd8-4d60-991c-1944a0b5d508.png">

<img width="446" alt="after" src="https://user-images.githubusercontent.com/73990/134050926-2c34bb30-7e63-418e-9a2c-4e3e60b0ca0f.png">